### PR TITLE
feat: development descriptor and enable script

### DIFF
--- a/scripts/register_and_enable_dev.sh
+++ b/scripts/register_and_enable_dev.sh
@@ -1,0 +1,30 @@
+BASEDIR=$(dirname "$0")
+# echo Please make sure you have run ./gradlew clean generateDescriptors before starting this script
+pushd "$BASEDIR/../service"
+
+# Check for decriptor target directory.
+
+DESCRIPTORDIR="build/resources/main/okapi"
+
+if [ ! -d "$DESCRIPTORDIR" ]; then
+    echo "No descriptors found. Let's try building them."
+    ./gradlew generateDescriptors
+fi
+
+DEP_DESC=`cat ${DESCRIPTORDIR}/DeploymentDescriptorDev.json`
+SVC_ID=`echo $DEP_DESC | jq -rc '.srvcId'`
+INS_ID=`echo $DEP_DESC | jq -rc '.instId'`
+
+echo Delete previous install
+
+curl -XDELETE "http://localhost:9130/_/proxy/tenants/diku/modules/${SVC_ID}"
+curl -XDELETE "http://localhost:9130/_/discovery/modules/${SVC_ID}/${INS_ID}"
+curl -XDELETE "http://localhost:9130/_/proxy/modules/${SVC_ID}"
+
+echo Install new module
+# ./gradlew clean generateDescriptors
+curl -XPOST 'http://localhost:9130/_/proxy/modules' -d @"${DESCRIPTORDIR}/ModuleDescriptor.json"
+curl -XPOST 'http://localhost:9130/_/discovery/modules' -d "$DEP_DESC"
+curl -XPOST 'http://localhost:9130/_/proxy/tenants/diku/install?tenantParameters=loadSample%3Dtest,loadReference%3Dother' -d `echo $DEP_DESC | jq -c '[{id: .srvcId, action: "enable"}]'`
+popd
+

--- a/service/src/main/okapi/DeploymentDescriptorDev-template.json
+++ b/service/src/main/okapi/DeploymentDescriptorDev-template.json
@@ -1,0 +1,5 @@
+{
+  "srvcId": "${info.app.name}-${info.app.version}",
+  "instId": "10.0.2.2-${info.app.name}-${info.app.version}",
+  "url": "http://10.0.2.2:8078/"
+}


### PR DESCRIPTION
Created a Development only module descriptor, deploymentDescriptorDev which can be used using 'register_and_enable_dev.sh' to run the module on port 8078