### PR TITLE
ERM-2433: Upgrade hibernate, postgresql, opencsv, minio, okhttp, kotlin

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -132,14 +132,14 @@ dependencies {
   compile "org.hibernate:hibernate-core:5.4.19.Final"             // Update to latest 5.4
   compile "org.hibernate:hibernate-java8:5.4.19.Final"
   runtime "com.zaxxer:HikariCP:3.4.5"                             // Replaces Tomcat JDBC pool
-  runtime "org.postgresql:postgresql:42.2.14"
+  runtime "org.postgresql:postgresql:42.5.0"
 
   compile ('org.grails.plugins:database-migration:3.1.0') {       // Required by Grails Okapi
     exclude group: 'org.liquibase', module: 'liquibase-core'
   }
   compile 'org.liquibase:liquibase-core:3.9.0'
 
-  compile 'com.opencsv:opencsv:4.6'
+  compile 'com.opencsv:opencsv:5.7.1'
   compile 'commons-io:commons-io:2.6'
 
   compile 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'     // TODO: Migrate away from this resource.

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -132,7 +132,7 @@ dependencies {
   compile "org.hibernate:hibernate-core:5.4.19.Final"             // Update to latest 5.4
   compile "org.hibernate:hibernate-java8:5.4.19.Final"
   runtime "com.zaxxer:HikariCP:3.4.5"                             // Replaces Tomcat JDBC pool
-  runtime "org.postgresql:postgresql:42.5.0"
+  runtime "org.postgresql:postgresql:42.5.3"
 
   compile ('org.grails.plugins:database-migration:3.1.0') {       // Required by Grails Okapi
     exclude group: 'org.liquibase', module: 'liquibase-core'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -143,8 +143,8 @@ dependencies {
   compile 'commons-io:commons-io:2.6'
 
   compile 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'     // TODO: Migrate away from this resource.
-  compile 'com.k_int.grails:web-toolkit-ce:5.2.0'
-  compile 'com.k_int.okapi:grails-okapi:4.1.1'
+  compile 'com.k_int.grails:web-toolkit-ce:6.4.1'
+  compile 'com.k_int.okapi:grails-okapi:5.0.1'
 
   // Custom non profile deps.
   compile 'org.apache.kafka:kafka-clients:2.3.0'


### PR DESCRIPTION
build: Dependencies

Bumped dependencies for postgresql, opencsv, minio okhttp and kotlin-stdlib. These have been tested to the best of my abilities, although I am not 100% certain no problems will arise due to their updating

ERM-2433