### PR TITLE
fix: Serials sequence EAN13

### DIFF
--- a/service/grails-app/services/org/olf/HousekeepingService.groovy
+++ b/service/grails-app/services/org/olf/HousekeepingService.groovy
@@ -136,7 +136,7 @@ public class HousekeepingService {
                   name: 'Pattern number',
                   code:'patternNumber',
                   format:'000000000',
-                  checkDigitAlgo:'None',
+                  checkDigitAlgo:'EAN13',
                   outputTemplate:'sm-${generated_number}-${checksum}'
                 ],
               ]


### PR DESCRIPTION
Added EAN13 as checkDigitAlgo to serials pattern number to ensure the checksum within the template does not show as null