### PR TITLE
fix: Permissions oversight (tangentially refs SI-43)

### DIFF
--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -599,7 +599,8 @@
         "servint.numberGenerator.collection.get",
         "servint.numberGenerator.item.get",
         "servint.numberGeneratorSequence.collection.get",
-        "servint.numberGeneratorSequence.item.get"
+        "servint.numberGeneratorSequence.item.get",
+        "servint.refdata.read"
       ]
     },
     {


### PR DESCRIPTION
Fixes permissions oversight where a user can have permissions to view number generators but not the refdata necessary to properly display those. Becomes more of an issue upstream as you cannot then select from the refdata for editing/creating. This fix adds the refdata.read permission as a subperm to the base numberGenerator.view permission

Tangentially refs SI-43 (in that it is about permission cleanup)