### PR TITLE
feat: SI-45: Dashboards not displaying after upgrade to Poppy

### DIFF
--- a/service/grails-app/controllers/org/olf/ActionController.groovy
+++ b/service/grails-app/controllers/org/olf/ActionController.groovy
@@ -29,5 +29,14 @@ class AdminController {
     result.status = 'OK'
     render result as JSON
   }
+
+  public ensureDisplayData() {
+    def result = [:]
+    log.debug("AdminController::ensureDisplayData");
+    utilityService.ensureDisplayData()
+
+    result.status = 'OK'
+    render result as JSON
+  }
 }
 

--- a/service/grails-app/services/org/olf/UtilityService.groovy
+++ b/service/grails-app/services/org/olf/UtilityService.groovy
@@ -128,4 +128,18 @@ class UtilityService {
     }
   }
 
+  public void ensureDisplayData() {
+    log.info("UtilityService::EnsureDisplayData")
+    Dashboard.executeQuery("""
+    SELECT d.id FROM Dashboard AS d
+    LEFT JOIN DashboardDisplayData AS ddd
+    ON d.id = ddd.dashId
+    WHERE ddd.id IS NULL
+    """.toString()).each{ dashId ->
+      log.debug("Found dashboard without display data (${dashId}), creating.")
+      DashboardDisplayData ddd = new DashboardDisplayData([
+        dashId: dashId
+      ]).save(flush: true, failOnError: true);
+    }
+  }
 }


### PR DESCRIPTION
Added new "ensureDisplayData" endpoint task which will create any missing dashboard display data entries

SI-45