### PR TITLE
chore: Tweak testing env

### DIFF
--- a/service/grails-app/conf/application.yml
+++ b/service/grails-app/conf/application.yml
@@ -158,7 +158,7 @@ dataSource:
 environments:
   test:
     dataSource:
-      url: "jdbc:postgresql://${db.host:localhost}:${db.port:54321}/${db.database:okapi_modules}"
+      url: "jdbc:postgresql://${db.host:localhost}:${db.port:54321}/${db.database:okapi_modules_test}"
       properties:
         initialSize: 7
         minIdle: 2


### PR DESCRIPTION
Changed so int tests use okapi_modules_test db, in line with other modules