### PR TITLE
ERM-3176: Review outdated/vulnerable dependencies in mod-service-interaction

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -96,7 +96,10 @@ dependencies {
   implementation "org.hibernate:hibernate-core:5.6.15.Final"
   implementation "org.grails.plugins:events"
 
-  implementation 'org.grails.plugins:spring-security-core:6.1.1' // Prev 5.2.1
+  implementation 'org.grails.plugins:spring-security-core:6.1.1' // NOT IN LINE WITH GRAILS PATCH VERSION
+  // 5.8.9 affected by https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKSECURITY-6457293
+  implementation("org.springframework.security:spring-security-core:5.8.11")
+
 
   implementation "org.grails.plugins:views-json"
   implementation "org.grails.plugins:views-json-templates"
@@ -133,7 +136,7 @@ dependencies {
 	implementation "org.springframework.boot:spring-boot-starter-undertow" // Replaces spring-boot-starter-tomcat
 	implementation "org.hibernate:hibernate-java8"
 	runtimeOnly "com.zaxxer:HikariCP:5.1.0"                             // Replaces Tomcat JDBC pool
-	runtimeOnly "org.postgresql:postgresql:42.5.3"
+  runtimeOnly "org.postgresql:postgresql:42.7.3"
 
   implementation ('org.grails.plugins:database-migration:4.2.1') {
 		exclude group: 'org.liquibase', module: 'liquibase-core'
@@ -141,9 +144,11 @@ dependencies {
 	implementation 'org.liquibase:liquibase-core:4.19.0' // Prev 4.17.2 -- taken from master of plugin database migration
 
 	implementation 'com.opencsv:opencsv:5.7.1'
-	implementation 'commons-io:commons-io:2.6'
-	implementation 'io.github.virtualdogbert:logback-groovy-config:1.14.1' // Grails 5 and up no longer supports groovy files for logback config
-	compileOnly 'ch.qos.logback:logback-classic:1.4.7'
+  implementation 'commons-io:commons-io:2.7'
+  implementation('io.github.virtualdogbert:logback-groovy-config:1.14.1')
+  compileOnly 'ch.qos.logback:logback-classic:1.4.7'
+  // Is on runtime classpath via spring-boot-starter
+  runtimeOnly 'ch.qos.logback:logback-classic:1.2.13'
 
 	/*  ---- Manually installed testing dependencies ---- */
 	//implementation "org.grails:grails-gorm-testing-support:2.6.1"
@@ -158,8 +163,9 @@ dependencies {
 	implementation 'org.z3950.zing:cql-java:1.13'
 
 	/* ---- Custom non profile deps ---- */
-	implementation 'org.apache.kafka:kafka-clients:2.3.0'
-	implementation 'com.github.everit-org.json-schema:org.everit.json.schema:1.14.3'
+  implementation 'org.apache.kafka:kafka-clients:3.7.0'
+  implementation 'com.github.everit-org.json-schema:org.everit.json.schema:1.14.4'
+
 	// Better test reports.
 	testImplementation( 'com.athaydes:spock-reports:2.3.2-groovy-3.0' ) {
 		transitive = false // this avoids affecting your version of Groovy/Spock

--- a/service/gradle.properties
+++ b/service/gradle.properties
@@ -1,5 +1,5 @@
-grailsVersion=6.1.1
-grailsGradlePluginVersion=6.1.1
+grailsVersion=6.1.2
+grailsGradlePluginVersion=6.1.2
 
 # Application
 appName=mod-service-interaction


### PR DESCRIPTION
build: Dependency upgrades

Bumped dependencies for security reasons
Bumped grails patch version to 6.1.2 to bring in line with other modules

ERM-3176