### PR TITLE
ERM-3190: DB connections are not being released

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -127,7 +127,7 @@ dependencies {
 
   /*  ---- Manually installed dependencies ---- */
 	implementation 'com.k_int.grails:web-toolkit-ce:9.0.0'
-	implementation('com.k_int.okapi:grails-okapi:7.0.0') {
+	implementation('com.k_int.okapi:grails-okapi:7.1.0') {
     exclude group: 'com.vaadin.external.google', module: 'android-json'
   }
 


### PR DESCRIPTION
fix: Issue with missing datasource on startup

Extra affordances given on startup when attempting to grab datasource from grails. Comprises of an update to grails-okapi -> 7.1.0

refs ERM-3190