### PR TITLE
fix: Fix checksum handling for "none" checksum

### DIFF
--- a/service/grails-app/controllers/org/olf/numberGenerator/NumberGeneratorController.groovy
+++ b/service/grails-app/controllers/org/olf/numberGenerator/NumberGeneratorController.groovy
@@ -197,11 +197,11 @@ class NumberGeneratorController extends OkapiTenantAwareController<NumberGenerat
     result = new NumberGeneratorSequence(owner: ng,
                                          name: sequence, // Set up default name
                                          code: sequence,
-                                         prefix: null,
-                                         postfix: null,
+                                         checkDigitAlgo: 'none',
                                          format: '000000000',  // Default to a 9 digit 0 padded number
                                          nextValue: 1,
-                                         outputTemplate:null).save(flush:true, failOnError:true);
+                                         outputTemplate:null
+                                        ).save(flush:true, failOnError:true);
     return result;
   }
 

--- a/service/grails-app/controllers/org/olf/numberGenerator/NumberGeneratorController.groovy
+++ b/service/grails-app/controllers/org/olf/numberGenerator/NumberGeneratorController.groovy
@@ -95,8 +95,11 @@ class NumberGeneratorController extends OkapiTenantAwareController<NumberGenerat
             DecimalFormat df = ngs.format ? new DecimalFormat(ngs.format) : null;
             String generated_number = df ? df.format(next_seqno) : next_seqno.toString();
             String checksum_input_template = applyPreChecksumTemplate ( ngs, generated_number );
-            String checksum = ngs.checkDigitAlgo ? generateCheckSum(ngs.checkDigitAlgo.value, checksum_input_template) : null;
-
+            String checksum = null;
+            if (ngs.checkDigitAlgo && ngs.checkDigitAlgo.value != 'none') {
+              checksum = generateCheckSum(ngs.checkDigitAlgo.value, checksum_input_template)
+            }
+      
             // If we don't override the template generate strings of the format
             // prefix-number-postfix-checksum
             Map template_parameters = [

--- a/service/src/integration-test/groovy/org/olf/NumberGeneratorSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/NumberGeneratorSpec.groovy
@@ -42,7 +42,7 @@ class NumberGeneratorSpec extends BaseSpec {
         'sequences':[
           [ 'name': 'patron',    'code': 'patron',    'prefix':'user',      'postfix':null,       'format':'000000000',         'enabled':true ],
           [ 'name': 'staff',     'code': 'staff',     'prefix':'staff',     'postfix':'test',     'format':'000,000,000',       'enabled':true ],
-          [ 'name': 'noformat',  'code': 'noformat',  'prefix':'nf',        'checkDigitAlgo': 'None'            'enabled':true ],
+          [ 'name': 'noformat',  'code': 'noformat',  'prefix':'nf',        'checkDigitAlgo': 'None',            'enabled':true ],
           [ 'name': 'highinit',  'code': 'highinit',  'prefix':'hi',        'format':'000000000', 'nextValue':100000,           'enabled':true ],
           [ 'name': 'mod10test', 'code': 'mod10test', 'format':'000000000', 'nextValue':100000,   'checkDigitAlgo': 'ModulusTenCheckDigit', 'enabled':true ],
           [ 'name': 'mod11test', 'code': 'mod11test', 'format':'000000000', 'nextValue':100000,   'checkDigitAlgo': 'ISBN10CheckDigit', 'enabled':true ],

--- a/service/src/integration-test/groovy/org/olf/NumberGeneratorSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/NumberGeneratorSpec.groovy
@@ -42,7 +42,7 @@ class NumberGeneratorSpec extends BaseSpec {
         'sequences':[
           [ 'name': 'patron',    'code': 'patron',    'prefix':'user',      'postfix':null,       'format':'000000000',         'enabled':true ],
           [ 'name': 'staff',     'code': 'staff',     'prefix':'staff',     'postfix':'test',     'format':'000,000,000',       'enabled':true ],
-          [ 'name': 'noformat',  'code': 'noformat',  'prefix':'nf',        'enabled':true ],
+          [ 'name': 'noformat',  'code': 'noformat',  'prefix':'nf',        'checkDigitAlgo': 'None'            'enabled':true ],
           [ 'name': 'highinit',  'code': 'highinit',  'prefix':'hi',        'format':'000000000', 'nextValue':100000,           'enabled':true ],
           [ 'name': 'mod10test', 'code': 'mod10test', 'format':'000000000', 'nextValue':100000,   'checkDigitAlgo': 'ModulusTenCheckDigit', 'enabled':true ],
           [ 'name': 'mod11test', 'code': 'mod11test', 'format':'000000000', 'nextValue':100000,   'checkDigitAlgo': 'ISBN10CheckDigit', 'enabled':true ],


### PR DESCRIPTION
checkDigitAlgo null is no longer the only way to specify no checksum... it also applies for checkDigitAlgo "None"

Added "none" test case