### PR TITLE
fix: invertChecksum

### DIFF
--- a/service/grails-app/controllers/org/olf/numberGenerator/NumberGeneratorController.groovy
+++ b/service/grails-app/controllers/org/olf/numberGenerator/NumberGeneratorController.groovy
@@ -142,7 +142,7 @@ class NumberGeneratorController extends OkapiTenantAwareController<NumberGenerat
 	}
 
   private String invertChecksum(String checksum, int base = 10) {
-    return (base - Integer.parseInt(checksum)).toString();
+    return ((base - Integer.parseInt(checksum)) % base).toString();
   }
 
   // See https://www.activebarcode.com/codes/checkdigit/modulo47.html


### PR DESCRIPTION
Previously invertChecksum was used to allow the implementation to "invert" the built in checksum library's behaviour to do (base-calculation). Some checksums require instead the calculation outright so for now we re-invert to return the original checksum calculation (an inelegant solution). However while it works for numbers up to and including the base:

`10 - (10-9) = 9` etc. It falls down at the base itself `10 - (10-10) = 10`. This is because an extra step is needed to ensure that the answer itself is modulo `<base>`.