### PR TITLE
chore: remove okapi from requires section of ModuleDescriptor - it pr…

### DIFF
--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -477,12 +477,6 @@
       ]
     }
   ],
-  "requires": [
-    {
-      "id": "okapi",
-      "version": "1.9"
-    }
-  ],
   "permissionSets": [
     {
       "permissionName": "servint.settings.get",


### PR DESCRIPTION
…events the descriptor from validating as okapi itself does not appear in the registry