### PR TITLE
ERM-3306: Dependency upgrades

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -98,9 +98,9 @@ dependencies {
   implementation "org.hibernate:hibernate-core:5.6.15.Final"
   implementation "org.grails.plugins:events"
 
-  implementation 'org.grails.plugins:spring-security-core:6.1.1' // NOT IN LINE WITH GRAILS PATCH VERSION
+  implementation 'org.grails.plugins:spring-security-core:6.1.2' // NOT IN LINE WITH GRAILS PATCH VERSION
   // 5.8.9 affected by https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKSECURITY-6457293
-  implementation("org.springframework.security:spring-security-core:5.8.11")
+//  implementation("org.springframework.security:spring-security-core:5.8.11")
 
 
   implementation "org.grails.plugins:views-json"

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -100,8 +100,10 @@ dependencies {
 
   implementation 'org.grails.plugins:spring-security-core:6.1.2' // NOT IN LINE WITH GRAILS PATCH VERSION
   // 5.8.9 affected by https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKSECURITY-6457293
-//  implementation("org.springframework.security:spring-security-core:5.8.11")
+  implementation("org.springframework.security:spring-security-core:5.8.16")
+  implementation("org.springframework.security:spring-security-web:5.8.16")
 
+  implementation 'com.squareup.okhttp3:okhttp:4.12.0'
 
   implementation "org.grails.plugins:views-json"
   implementation "org.grails.plugins:views-json-templates"
@@ -160,7 +162,7 @@ dependencies {
 	implementation 'org.liquibase:liquibase-core:4.19.0' // Prev 4.17.2 -- taken from master of plugin database migration
 
 	implementation 'com.opencsv:opencsv:5.7.1'
-  implementation 'commons-io:commons-io:2.7'
+  implementation 'commons-io:commons-io:2.14.0'
   implementation('io.github.virtualdogbert:logback-groovy-config:1.14.1')
   compileOnly 'ch.qos.logback:logback-classic:1.4.7'
   // Is on runtime classpath via spring-boot-starter

--- a/service/gradle.properties
+++ b/service/gradle.properties
@@ -1,5 +1,5 @@
-grailsVersion=6.1.2
-grailsGradlePluginVersion=6.1.2
+grailsVersion=6.2.3
+grailsGradlePluginVersion=6.2.3
 
 # Application
 appName=mod-service-interaction

--- a/service/settings.gradle
+++ b/service/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
         gradlePluginPortal()
     }
     plugins {
-        id "org.grails.grails-web" version "6.1.1"
+        id "org.grails.grails-web" version "6.2.3"
         id "org.grails.plugins.views-json" version "3.1.1"
     }
 }


### PR DESCRIPTION
Builds locally and passes integration tests.

upgrades grailsVersion=6.1.1 to grailsVersion=6.2.3
upgrades "org.grails.plugins:spring-security-core:6.1.1" to "org.grails.plugins:spring-security-core:6.1.2"

Also comments out/removes the implementation("org.springframework.security:spring-security-core:5.8.11") dependency - is this necessary when we are pulling in the grails spring security core? It didn't affect the build or integration tests locally but unsure if this is required for deployment.

Dependencies export-
[deps-upgrade.txt](https://github.com/user-attachments/files/20505410/deps-upgrade.txt)
