### PR TITLE
SI-95 fix: Show HitMaximum warning when max reached without threshold

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 4.3.0 IN PROGRESS
+  * SI-95 HitMaximum warning not shown when maximum reached without threshold configured
 
 ## 4.2.3 2025-11-28
   * ERM-3851 Long standing connection issues bug


### PR DESCRIPTION
# Issue
[SI-95](https://folio-org.atlassian.net/browse/SI-95)
# Summary
- Fixed bug where HitMaximum warning was not returned when a sequence reached its maximum value without a warning threshold configured
- Refactored switch statement with extracted helper methods for improved readability
- Added comprehensive test coverage for warning/error scenarios