### PR TITLE
ERM-3223: Upgrade commons-io from 2.7 to 2.14.0 fixing XML DoS vuln

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 4.3.0 IN PROGRESS
   * SI-95 HitMaximum warning not shown when maximum reached without threshold configured
+  * ERM-3223 Upgrade commons-io from 2.7 to 2.14.0 fixing XML DoS CVE-2024-47554
 
 ## 4.2.3 2025-11-28
   * ERM-3851 Long standing connection issues bug

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -160,7 +160,7 @@ dependencies {
 	implementation 'org.liquibase:liquibase-core:4.19.0' // Prev 4.17.2 -- taken from master of plugin database migration
 
 	implementation 'com.opencsv:opencsv:5.7.1'
-  implementation 'commons-io:commons-io:2.7'
+  implementation 'commons-io:commons-io:2.14.0'
   implementation('io.github.virtualdogbert:logback-groovy-config:1.14.1')
   compileOnly 'ch.qos.logback:logback-classic:1.4.7'
   // Is on runtime classpath via spring-boot-starter


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/ERM-3223

Bump commons-io from 2.7 to 2.14.0 fixing this vulnerability:

* CVE-2024-47554 - https://github.com/advisories/GHSA-78wr-2p64-hpwj - Denial of service attack on untrusted input to XmlStreamReader