### PR TITLE
SI-171: Integrate numberGenerator for instance identifier

### DIFF
--- a/service/grails-app/services/org/olf/HousekeepingService.groovy
+++ b/service/grails-app/services/org/olf/HousekeepingService.groovy
@@ -190,6 +190,19 @@ public class HousekeepingService {
               ]
             ],
             [
+              name:'Inventory: Instance identifier',
+              code:'inventory_instanceIdentifier',
+              sequences: [
+                [
+                  name: 'Instance identifier',
+                  code: 'instanceIdentifier',
+                  format:'0000000000',
+                  checkDigitAlgo:'None',
+                  outputTemplate:'${generated_number}'
+                ],
+              ]
+            ],
+            [
               name:'Serials management: Pattern number',
               code:'serialsManagement_patternNumber',
               sequences: [


### PR DESCRIPTION
[SI-171](https://folio-org.atlassian.net/browse/SI-171)

**Description**

Integrate number generator for Instance identifier

In Settings > Service integration > Number generators a new number generator needs to be integrated and displayed (reference data)

- for Instance identifier in Inventory Instance level 
- **Name = Inventory: Instance identifier**
- **Code = inventory_instanceIdentifier**
- same functionality like other number generators e.g. item barcode in Inventory
- same capability/capability set for Service interaction
- Integrate number generator sequence functionality for Instance identifier
- same functionality to define sequences by selecting Inventory: Instance identifier (Code = inventory_instanceIdentifier) in the Generator drop-down 